### PR TITLE
WIP - catch and bubble up 401 status code

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,6 +164,9 @@ function SpotifyResolve(createOpts) {
       if (error) {
         done(error);
       }
+      else if (response.statusCode === 401) {
+        done(new Error(response.statusCode), response);
+      }
       else {
         done(error, results[apiInfo.relevantResultProperty]);
       }

--- a/index.js
+++ b/index.js
@@ -165,7 +165,9 @@ function SpotifyResolve(createOpts) {
         done(error);
       }
       else if (response.statusCode === 401) {
-        done(new Error(response.statusCode), response);
+        var unauthorizedError = new Error('Authorization Error: received status code ' + response.statusCode);
+        unauthorizedError.name = response.statusCode;
+        done(unauthorizedError, response);
       }
       else {
         done(error, results[apiInfo.relevantResultProperty]);


### PR DESCRIPTION
Now that Spotify Web API requires authentication for all endpoints, we should catch and bubble up any `401 Unauthorized` errors to the application for handling. 

Currently, the existing tests on `master` are failing due to lack of authentication. As I will be fixing and adding test cases, this PR is marked WIP.