### PR TITLE
use more descriptive error name

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ function SpotifyResolve(createOpts) {
       }
       else if (response.statusCode === 401) {
         var unauthorizedError = new Error('Authorization Error: received status code ' + response.statusCode);
-        unauthorizedError.name = response.statusCode;
+        unauthorizedError.name = 'Unauthorized';
         done(unauthorizedError, response);
       }
       else {


### PR DESCRIPTION
Use a better, more descriptive name for `401` errors.